### PR TITLE
Require omniauth to avoid error

### DIFF
--- a/lib/omniauth/strategies/facebook-access-token.rb
+++ b/lib/omniauth/strategies/facebook-access-token.rb
@@ -1,4 +1,5 @@
 require 'oauth2'
+require 'omniauth'
 
 module OmniAuth
   module Strategies


### PR DESCRIPTION
I was getting an error: uninitialized constant OmniAuth::Strategy (NameError).  Requiring omniauth seems to fix it.
