### PR TITLE
Fix SSL to last version available

### DIFF
--- a/lib/omniauth/strategies/facebook-access-token.rb
+++ b/lib/omniauth/strategies/facebook-access-token.rb
@@ -15,7 +15,7 @@ module OmniAuth
       option :client_options, {
         :site => 'https://graph.facebook.com',
         :token_url => '/oauth/access_token',
-        :ssl => { :version => "TLSv1" }
+        :ssl => { :version => "SSLv23" }
       }
 
       option :access_token_options, {


### PR DESCRIPTION
Facebook just disabled SSLv3 due to security failures found on the protocol. See http://googleonlinesecurity.blogspot.com.br/2014/10/this-poodle-bites-exploiting-ssl-30.html
