### PR TITLE
switched ssl version to v23 as facebook returns an error on v3

### DIFF
--- a/lib/omniauth/strategies/facebook-access-token.rb
+++ b/lib/omniauth/strategies/facebook-access-token.rb
@@ -16,7 +16,7 @@ module OmniAuth
       option :client_options, {
         :site => 'https://graph.facebook.com',
         :token_url => '/oauth/access_token',
-        :ssl => { :version => "SSLv3" }
+        :ssl => { :version => "SSLv23" }
       }
 
       option :access_token_options, {


### PR DESCRIPTION
I started getting ssl handshaker errors from Facebook, so I switched to the version specifier to SSLv23.  The errors are gone now.
